### PR TITLE
Added configuration to not force message in error response

### DIFF
--- a/doc/errors.rst
+++ b/doc/errors.rst
@@ -189,3 +189,9 @@ It also allows for overriding the default error handler when used wihtout parame
     def default_error_handler(error):
         '''Default error handler'''
         return {'message': str(error)}, getattr(error, 'code', 500)
+
+.. note ::
+
+    Flask-RESTPlus will return a message in the error response by default.
+    If a custom response is required as an error and the message field is not needed,
+    it can be disabled by setting ``ERROR_INCLUDE_MESSAGE`` to ``False`` in your application config.

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -576,7 +576,7 @@ class Api(object):
         '''
         got_request_exception.send(current_app._get_current_object(), exception=e)
 
-        include_message_in_error = current_app.config.get("ERROR_INCLUDE_MESSAGE", True)
+        include_message_in_response = current_app.config.get("ERROR_INCLUDE_MESSAGE", True)
         default_data = {}
 
         headers = Headers()
@@ -586,7 +586,7 @@ class Api(object):
             default_data, code, headers = unpack(result, HTTPStatus.INTERNAL_SERVER_ERROR)
         elif isinstance(e, HTTPException):
             code = HTTPStatus(e.code)
-            if include_message_in_error:
+            if include_message_in_response:
                 default_data = {
                     'message': getattr(e, 'description', code.phrase)
                 }
@@ -596,12 +596,12 @@ class Api(object):
             default_data, code, headers = unpack(result, HTTPStatus.INTERNAL_SERVER_ERROR)
         else:
             code = HTTPStatus.INTERNAL_SERVER_ERROR
-            if include_message_in_error:
+            if include_message_in_response:
                 default_data = {
                     'message': code.phrase,
                 }
 
-        if include_message_in_error:
+        if include_message_in_response:
             default_data['message'] = default_data.get('message', str(e))
 
         data = getattr(e, 'data', default_data)
@@ -614,7 +614,7 @@ class Api(object):
             current_app.log_exception(exc_info)
 
         elif code == HTTPStatus.NOT_FOUND and current_app.config.get("ERROR_404_HELP", True) \
-                and include_message_in_error:
+                and include_message_in_response:
             data['message'] = self._help_on_404(data.get('message', None))
 
         elif code == HTTPStatus.NOT_ACCEPTABLE and self.default_mediatype is None:

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -576,6 +576,9 @@ class Api(object):
         '''
         got_request_exception.send(current_app._get_current_object(), exception=e)
 
+        include_message_in_error = current_app.config.get("ERROR_INCLUDE_MESSAGE", True)
+        default_data = {}
+
         headers = Headers()
         if e.__class__ in self.error_handlers:
             handler = self.error_handlers[e.__class__]
@@ -583,20 +586,23 @@ class Api(object):
             default_data, code, headers = unpack(result, HTTPStatus.INTERNAL_SERVER_ERROR)
         elif isinstance(e, HTTPException):
             code = HTTPStatus(e.code)
-            default_data = {
-                'message': getattr(e, 'description', code.phrase)
-            }
+            if include_message_in_error:
+                default_data = {
+                    'message': getattr(e, 'description', code.phrase)
+                }
             headers = e.get_response().headers
         elif self._default_error_handler:
             result = self._default_error_handler(e)
             default_data, code, headers = unpack(result, HTTPStatus.INTERNAL_SERVER_ERROR)
         else:
             code = HTTPStatus.INTERNAL_SERVER_ERROR
-            default_data = {
-                'message': code.phrase,
-            }
+            if include_message_in_error:
+                default_data = {
+                    'message': code.phrase,
+                }
 
-        default_data['message'] = default_data.get('message', str(e))
+        if include_message_in_error:
+            default_data['message'] = default_data.get('message', str(e))
 
         data = getattr(e, 'data', default_data)
         fallback_mediatype = None
@@ -607,7 +613,8 @@ class Api(object):
                 exc_info = None
             current_app.log_exception(exc_info)
 
-        elif code == HTTPStatus.NOT_FOUND and current_app.config.get("ERROR_404_HELP", True):
+        elif code == HTTPStatus.NOT_FOUND and current_app.config.get("ERROR_404_HELP", True) \
+                and include_message_in_error:
             data['message'] = self._help_on_404(data.get('message', None))
 
         elif code == HTTPStatus.NOT_ACCEPTABLE and self.default_mediatype is None:
@@ -621,9 +628,6 @@ class Api(object):
         # Remove blacklisted headers
         for header in HEADERS_BLACKLIST:
             headers.pop(header, None)
-
-        if not current_app.config.get("ERROR_INCLUDE_MESSAGE", True):
-            del data['message']
 
         resp = self.make_response(data, code, headers, fallback_mediatype=fallback_mediatype)
 

--- a/flask_restplus/api.py
+++ b/flask_restplus/api.py
@@ -597,6 +597,7 @@ class Api(object):
             }
 
         default_data['message'] = default_data.get('message', str(e))
+
         data = getattr(e, 'data', default_data)
         fallback_mediatype = None
 
@@ -620,6 +621,9 @@ class Api(object):
         # Remove blacklisted headers
         for header in HEADERS_BLACKLIST:
             headers.pop(header, None)
+
+        if not current_app.config.get("ERROR_INCLUDE_MESSAGE", True):
+            del data['message']
 
         resp = self.make_response(data, code, headers, fallback_mediatype=fallback_mediatype)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -405,6 +405,16 @@ class ErrorsTest(object):
             'message': NotFound.description
         }
 
+    def test_handle_include_error_message(self, app):
+        api = restplus.Api(app)
+        view = restplus.Resource
+
+        api.add_resource(view, '/foo', endpoint='bor')
+
+        with app.test_request_context("/faaaaa"):
+            response = api.handle_error(NotFound())
+            assert 'message' in json.loads(response.data.decode())
+
     def test_handle_not_include_error_message(self, app):
         app.config['ERROR_INCLUDE_MESSAGE'] = False
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -405,6 +405,18 @@ class ErrorsTest(object):
             'message': NotFound.description
         }
 
+    def test_handle_not_include_error_message(self, app):
+        app.config['ERROR_INCLUDE_MESSAGE'] = False
+
+        api = restplus.Api(app)
+        view = restplus.Resource
+
+        api.add_resource(view, '/foo', endpoint='bor')
+
+        with app.test_request_context("/faaaaa"):
+            response = api.handle_error(NotFound())
+            assert 'message' not in json.loads(response.data.decode())
+
     def test_error_router_falls_back_to_original(self, app, mocker):
         api = restplus.Api(app)
         app.handle_exception = mocker.Mock()


### PR DESCRIPTION
Flask-RESTPlus will return a message in the error response by default, which works great in common scenarios. As a developer, if a custom response is required as an error, Flask-RESTPlus will include a message field in this error response. In some scenarios, including the message field is not ideal.

At the moment, it is not possible to exclude/remove the message field in the error response. To handle this requirement, a new configuration option has been added to not include message in the error response.

To disable the default behaviour, set the ERROR_INCLUDE_MESSAGE setting to False in the application config.